### PR TITLE
add local_date field to transformer ScheduleEventTransformer

### DIFF
--- a/src/Http/Controllers/ScheduleEventsNestedController.php
+++ b/src/Http/Controllers/ScheduleEventsNestedController.php
@@ -20,7 +20,7 @@ class ScheduleEventsNestedController extends BaseResourceController
     public function index(Request $request, int $schedule_id)
     {
         $this->repository->clearQuery();
-        $this->repository->query()->where('schedule_id', $schedule_id);
+        $this->repository->query()->with('schedule')->where('schedule_id', $schedule_id);
         return $this->apiIndex($request);
     }
 

--- a/src/Transformer/ScheduleEventTransformer.php
+++ b/src/Transformer/ScheduleEventTransformer.php
@@ -17,6 +17,10 @@ class ScheduleEventTransformer extends TransformerAbstract implements Transforme
     public function transform(ScheduleEvent $schedule_event) : array
     {
         $array = $schedule_event->toArray();
+        if ($schedule_event->relationLoaded('schedule')) {
+            $array['local_date'] = $schedule_event->date->timezone($schedule_event->schedule->timezone);
+            unset($array['schedule']);
+        }
         $array['links'] = $this->getLinks($schedule_event);
         return $array;
     }


### PR DESCRIPTION
- This requires the schedule relationship to be eager loaded to prevent excessive querying.
- Eager load schedule in ScheduleEventNestedController