### PR TITLE
Load schedule when updating

### DIFF
--- a/src/Http/Controllers/ScheduleEventsNestedController.php
+++ b/src/Http/Controllers/ScheduleEventsNestedController.php
@@ -89,7 +89,7 @@ class ScheduleEventsNestedController extends BaseResourceController
             if ($this->repository->update($id, $request->all())) {
                 $this->postUpdate($request, $item);
                 $item = $item->fresh();
-                return $this->sendResponse($this->transform($item->fresh()));
+                return $this->sendResponse($this->transform($item->fresh()->load('schedule')));
             }
 
             return $this->sendError(sprintf('%s could not be saved', class_basename($this->repository->getModelName())), $response_code = 402);


### PR DESCRIPTION
So that the transformer sends back the timezone aware local_date key

This is to address the issues in CC-1265 where a user will add and then update a new schedule event but is expecting a local_date key to display this date and time correctly.