### PR TITLE
Feature/periodic fix

### DIFF
--- a/src/Library/ScheduleParser/Periodic/Months.php
+++ b/src/Library/ScheduleParser/Periodic/Months.php
@@ -59,13 +59,8 @@ class Months extends Base implements ScheduleParserContract
                 $iteration_count++;
             }
         }
-
-        $raw = $this->generated;
-
+        
         $this->generated = $this->filterExceptions($this->generated);
-
-        // dd($raw, '---', $this->generated, '---------', $this->getRangeStart(), $this->getRangeEnd());
-        // dd($raw, '---', $this->generated);
 
         $this->sortDates();
         $this->fixTimezones();

--- a/src/Library/ScheduleParser/Periodic/Months.php
+++ b/src/Library/ScheduleParser/Periodic/Months.php
@@ -26,11 +26,12 @@ class Months extends Base implements ScheduleParserContract
                 $year = $current_date->year;
 
                 if ($current_date->format('j') == $day_number) {
-                    if ($month == 12) {
-                        $month = 1;
-                        $year = $year + 1;
-                    } else {
+                    if ($month <= 12) {
                         $month = $month + $interval;
+                    }
+                    if ($month > 12) {
+                        $month = $month - 12;
+                        $year = $year + 1;
                     }
                 }
 
@@ -39,17 +40,16 @@ class Months extends Base implements ScheduleParserContract
                         $modification_string = sprintf('%s %s of %s %s', $this->getWeekNumberAsString(), $this->formatShortDay($day_name, 'l'), $current_date->format('F'), $current_date->year);
                         $current_date->modify($modification_string)->setTime(...explode(':', $this->getTimeOfDay()));
                         if ($current_date->lte($this->getRangeEnd()) && $current_date->gte($this->getRangeStart())) {
-                            $this->generated[] = $current_date->copy();
+                                $this->generated[] = $current_date->copy();
                         }
                     }
                 } else {
                     if ($current_date->between($this->getRangeStart(), $this->getRangeEnd()) &&
                         $current_date->format('j') == $day_number
                     ) {
-                        $this->generated[] = $current_date->copy();
+                            $this->generated[] = $current_date->copy();
                     }
                 }
-
 
                 $current_date->month($month)->year($year);
                 while ($current_date->day != $day_number) {
@@ -60,7 +60,13 @@ class Months extends Base implements ScheduleParserContract
             }
         }
 
+        $raw = $this->generated;
+
         $this->generated = $this->filterExceptions($this->generated);
+
+        // dd($raw, '---', $this->generated, '---------', $this->getRangeStart(), $this->getRangeEnd());
+        // dd($raw, '---', $this->generated);
+
         $this->sortDates();
         $this->fixTimezones();
         return $this->generated;

--- a/src/Library/ScheduleParser/Periodic/Months.php
+++ b/src/Library/ScheduleParser/Periodic/Months.php
@@ -59,9 +59,8 @@ class Months extends Base implements ScheduleParserContract
                 $iteration_count++;
             }
         }
-        
-        $this->generated = $this->filterExceptions($this->generated);
 
+        $this->generated = $this->filterExceptions($this->generated);
         $this->sortDates();
         $this->fixTimezones();
         return $this->generated;

--- a/src/Library/ScheduleParser/Periodic/Months.php
+++ b/src/Library/ScheduleParser/Periodic/Months.php
@@ -40,14 +40,14 @@ class Months extends Base implements ScheduleParserContract
                         $modification_string = sprintf('%s %s of %s %s', $this->getWeekNumberAsString(), $this->formatShortDay($day_name, 'l'), $current_date->format('F'), $current_date->year);
                         $current_date->modify($modification_string)->setTime(...explode(':', $this->getTimeOfDay()));
                         if ($current_date->lte($this->getRangeEnd()) && $current_date->gte($this->getRangeStart())) {
-                                $this->generated[] = $current_date->copy();
+                            $this->generated[] = $current_date->copy();
                         }
                     }
                 } else {
                     if ($current_date->between($this->getRangeStart(), $this->getRangeEnd()) &&
                         $current_date->format('j') == $day_number
                     ) {
-                            $this->generated[] = $current_date->copy();
+                        $this->generated[] = $current_date->copy();
                     }
                 }
 

--- a/tests/test_data/schedule_definitions_monthly.php
+++ b/tests/test_data/schedule_definitions_monthly.php
@@ -365,11 +365,14 @@ return [
         ],
     ],
     'Same week each month [every second monday] (excluding date outside date range)' => [
-        '{ "timezone": "Europe/London", "range": { "start": "2017-08-16", "end": "2017-11-30" }, "time_of_day": "09:00", "type": "periodic", "interval": 1, "period": "months", "day_number": false, "week_number": "second", "days": { "mon": true }, "months": {} }',
+        '{ "timezone": "Europe/London", "range": { "start": "2018-11-01", "end": "2019-04-30" }, "time_of_day": "09:00", "type": "periodic", "interval": 1, "period": "months", "day_number": false, "week_number": "second", "days": { "mon": true }, "months": {} }',
         [
-            '2017-09-11T08:00:00+00:00', // Mon, 11 Sep 2017 08:00:00 +0000
-            '2017-10-09T08:00:00+00:00', // Mon, 09 Oct 2017 08:00:00 +0000
-            '2017-11-13T09:00:00+00:00', // Mon, 13 Nov 2017 09:00:00 +0000
+            '2018-11-12T09:00:00+00:00', // Mon, 11 Sep 2017 08:00:00 +0000
+            '2018-12-10T09:00:00+00:00', // Mon, 09 Oct 2017 08:00:00 +0000
+            '2019-01-14T09:00:00+00:00', // Mon, 13 Nov 2017 09:00:00 +0000
+            '2019-02-11T09:00:00+00:00', // Mon, 13 Nov 2017 09:00:00 +0000
+            '2019-03-11T09:00:00+00:00', // Mon, 13 Nov 2017 09:00:00 +0000
+            '2019-04-08T08:00:00+00:00', // Mon, 13 Nov 2017 09:00:00 +0000
         ],
     ],
     'Same week each month (with two days and excluded month) [every second monday and wednesday] (excluding dates outside date range)' => [
@@ -439,6 +442,50 @@ return [
             '2017-09-11T08:00:00+00:00', // Mon, 11 Sep 2017 08:00:00 +0000
             '2017-10-09T08:00:00+00:00', // Mon, 09 Oct 2017 08:00:00 +0000
             '2017-11-13T09:00:00+00:00', // Mon, 13 Nov 2017 09:00:00 +0000
+        ],
+    ],
+    'Third day of every third month' => [
+        '{
+            "timezone": "UTC",
+            "range": {
+                "start": "2018-12-01",
+                "end": "2019-12-01"
+            },
+            "time_of_day": "10:00",
+            "type": "periodic",
+            "interval": 3,
+            "period": "months",
+            "day_number": 3,
+            "week_number": 0,
+            "days": {
+                "mon": true,
+                "tue": true,
+                "wed": true,
+                "thu": true,
+                "fri": true,
+                "sat": true,
+                "sun": true
+            },
+            "months": {
+                "jan": true,
+                "feb": true,
+                "mar": true,
+                "apr": true,
+                "may": true,
+                "jun": true,
+                "jul": true,
+                "aug": true,
+                "sep": true,
+                "oct": true,
+                "nov": true,
+                "dec": true
+            }
+        }',
+        [
+            '2018-12-03T10:00:00+00:00', 
+            '2019-03-03T10:00:00+00:00', 
+            '2019-06-03T10:00:00+00:00', 
+            '2019-09-03T10:00:00+00:00', 
         ],
     ],
 ];


### PR DESCRIPTION
Fixes a couple of issues.
1. Multiple month intervals (every 3 months for example) didn't work, instead generated an event for every day within the data ranges, all for the same date
2. The month increment reset on every new year. This was previously not noticed due to issue 1.

Potential todos:
- Improve cross year test coverage - currently altered one test to confirm behaviour
- Check this behaviour for other periods